### PR TITLE
Create separate prototype chain for Point

### DIFF
--- a/lib/crypto/point.js
+++ b/lib/crypto/point.js
@@ -30,7 +30,7 @@ var Point = function Point(x, y, isRed) {
   return point;
 };
 
-Point.prototype = Object.getPrototypeOf(ec.curve.point());
+Point.prototype = Object.create(Object.getPrototypeOf(ec.curve.point()));
 
 /**
  *


### PR DESCRIPTION
With the Point prototype set to the prototype of `ec.curve.point()` any changes to the Point prototype was changing the functionality in `ec.curve.point()`, which was causing this issue when integrating with the crypto-gateway
```
/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/@kaspa/core-lib/lib/crypto/point.js:125
    throw new Error('Invalid y value for curve.');
    ^

Error: Invalid y value for curve.
    at Point.validate (/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/@kaspa/core-lib/lib/crypto/point.js:125:11)
    at new PresetCurve (/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/elliptic/lib/elliptic/curves.js:22:17)
    at Object.get [as p256] (/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/elliptic/lib/elliptic/curves.js:32:19)
    at new EC (/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/elliptic/lib/elliptic/ec/index.js:22:21)
    at Object.<anonymous> (/Users/robbie.miller/Projects/uphold/crypto-gateway/node_modules/did-jwt/lib/index.cjs:478:21)
    at Module._compile (node:internal/modules/cjs/loader:1233:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1287:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
```

So to not alter the functionality on `ec.curve.point()` the Point prototype is set to a new object linked to the `ec.curve.point()` prototype 